### PR TITLE
module structure changes

### DIFF
--- a/docs/redpanda.md
+++ b/docs/redpanda.md
@@ -66,12 +66,13 @@ nixos-rebuild switch
 
 # Deploy a cluster
 
-To configure your broker as part of a cluster, you can specify a list of cluster nodes, and where they can be found. This setting should be the same across all nodes in a cluster, which can be done most easily by factoring the common configuration into a separate file, and importing into each machine's configuration.
+To configure your broker as part of a cluster, you can specify a list of cluster nodes, and where they can be found. This setting should be the same across all nodes in a cluster, which can be done most easily by factoring the common configuration into a separate file, and importing into each machine's configuration. All cluster settings go here as well.
 
 ```nix
 # cluster_configuration.nix
 {
-  services.redpanda.cluster.nodes = {
+  services.redpanda.cluster = {
+    nodes = {
       alpha = {
         rpc_api.address = "0.0.0.0";
         advertised_rpc_api.addresss = "alpha.somewhere.com";
@@ -89,6 +90,9 @@ To configure your broker as part of a cluster, you can specify a list of cluster
         advertised_kafka_api.addresss = "gamma.somewhere.com";
       };
       # ...
+    };
+    settings = {
+      default_topic_replications = 3;
     };
   };
 }
@@ -146,7 +150,7 @@ To switch to production mode set the `developer_mode` option to `false`.
 
 ```nix
 {
-  services.redpanda.settings.broker.redpanda.developer_mode = false;
+  services.redpanda.settings.redpanda.developer_mode = false;
 }
 ```
 
@@ -221,7 +225,7 @@ An example configuration looks like
 
 ```nix
 {
-  services.redpanda.settings.broker.redpanda = {
+  services.redpanda.settings.redpanda = {
     empty_seed_starts_cluster = false;
     seed_servers = [
       {
@@ -253,7 +257,7 @@ If you choose to assign broker IDs, make sure to use a fresh `node_id` each time
 
 ```nix
 {
-  services.redpanda.settings.broker.node_id = 0;
+  services.redpanda.settings.node_id = 0;
 }
 ```
 
@@ -283,7 +287,7 @@ Any cluster configuration command `rpk cluster config ...` should instead be set
 
 ```nix
 {
-  services.redpanda.settings.cluster = {
+  services.redpanda.cluster.settings = {
     # configuration goes here...
     # e.g.
     default_topic_replications = 3;
@@ -306,7 +310,7 @@ becomes
 ```nix
 # /etc/nixos/configuration.nix
 {
-  services.redpanda.settings.broker = {
+  services.redpanda.settings = {
     crash_loop_limit = 10;
     dashboard_dir = "/var/www/dashboard";
   };

--- a/docs/redpanda.md
+++ b/docs/redpanda.md
@@ -91,7 +91,7 @@ To configure your broker as part of a cluster, you can specify a list of cluster
       };
       # ...
     };
-    settings = {
+    broker.settings = {
       default_topic_replications = 3;
     };
   };
@@ -150,7 +150,7 @@ To switch to production mode set the `developer_mode` option to `false`.
 
 ```nix
 {
-  services.redpanda.settings.redpanda.developer_mode = false;
+  services.redpanda.broker.settings.redpanda.developer_mode = false;
 }
 ```
 
@@ -225,7 +225,7 @@ An example configuration looks like
 
 ```nix
 {
-  services.redpanda.settings.redpanda = {
+  services.redpanda.broker.settings.redpanda = {
     empty_seed_starts_cluster = false;
     seed_servers = [
       {
@@ -257,7 +257,7 @@ If you choose to assign broker IDs, make sure to use a fresh `node_id` each time
 
 ```nix
 {
-  services.redpanda.settings.node_id = 0;
+  services.redpanda.broker.settings.node_id = 0;
 }
 ```
 
@@ -297,7 +297,7 @@ Any cluster configuration command `rpk cluster config ...` should instead be set
 }
 ```
 
-Yaml configuration of broker properties will have to be renderered as a Nix attrset under the `services.redpanda.settings.broker` option. For example,
+Yaml configuration of broker properties will have to be renderered as a Nix attrset under the `services.redpanda.broker.settings` option. For example,
 
 ```yaml
 # /etc/redpanda/redpanda.yml
@@ -310,7 +310,7 @@ becomes
 ```nix
 # /etc/nixos/configuration.nix
 {
-  services.redpanda.settings = {
+  services.redpanda.broker.settings = {
     crash_loop_limit = 10;
     dashboard_dir = "/var/www/dashboard";
   };

--- a/modules/redpanda.nix
+++ b/modules/redpanda.nix
@@ -10,7 +10,7 @@ let
 
   yaml = pkgs.formats.yaml { };
 
-  brokerCfg = cfg.settings;
+  brokerCfg = cfg.broker.settings;
 
   brokerYaml = yaml.generate "redpanda.yaml" brokerCfg;
 
@@ -187,7 +187,7 @@ in
       };
     };
 
-    settings = mkOption {
+    broker.settings = mkOption {
       type = yaml.type;
       description = ''Broker configuration properties
 
@@ -205,7 +205,7 @@ in
       message = "If the redpanda option `iotune.file` is set, the corresponding `iotune.location` setting must be within `/etc/`";
     }];
 
-    services.redpanda.settings = mkMerge [
+    services.redpanda.broker.settings = mkMerge [
       # Reuse config for this nodeName in the cluster config.
       # TODO: should we assert that the current node is in the cluster? This seems most likely to be a mistake.
       #       maybe they can set nodeName = null; to opt out
@@ -217,7 +217,7 @@ in
           rpc_server = { address = mkDefault "127.0.0.1"; port = mkDefault 33145; };
           advertised_rpc_api = {
             address = mkDefault "0.0.0.0";
-            port = mkDefault cfg.settings.redpanda.rpc_server.port;
+            port = mkDefault cfg.broker.settings.redpanda.rpc_server.port;
           };
           kafka_api = mkDefault [
             { address = "0.0.0.0"; port = 9092; }

--- a/tests/cluster.nix
+++ b/tests/cluster.nix
@@ -14,7 +14,7 @@ let
     services.redpanda = {
       enable = true;
       autoRestart = true;
-      cluster = {
+      cluster.nodes = {
         server0 = {
           advertised_rpc_api.address = "server0";
           advertised_kafka_api = [{ address = "server0"; }];
@@ -29,19 +29,17 @@ let
         };
       };
       settings = {
-        broker = {
-          redpanda = {
-            rpc_server.address = "0.0.0.0";
-            developer_mode = true;
-            empty_seed_starts_cluster = false;
-          };
-          rpk.overprovisioned = false;
+        redpanda = {
+          rpc_server.address = "0.0.0.0";
+          developer_mode = true;
+          empty_seed_starts_cluster = false;
         };
+        rpk.overprovisioned = false;
       };
     };
     specialisation.trigger_restart.configuration = {
       # change a bunch of stuff that in theory needs a restart, because in practice a lot of it doesn't
-      services.redpanda.settings.cluster = {
+      services.redpanda.cluster.settings = {
         kafka_connection_rate_limit = lib.mkForce 20;
         aggregate_metrics = true;
         disable_public_metrics = true;

--- a/tests/cluster.nix
+++ b/tests/cluster.nix
@@ -28,7 +28,7 @@ let
           advertised_kafka_api = [{ address = "server2"; }];
         };
       };
-      settings = {
+      broker.settings = {
         redpanda = {
           rpc_server.address = "0.0.0.0";
           developer_mode = true;

--- a/tests/redpanda.nix
+++ b/tests/redpanda.nix
@@ -12,7 +12,7 @@ rebuildableTest {
       virtualisation.memorySize = 2 * 1024; # 2GiB
       services.redpanda = {
         enable = true;
-        settings = {
+        broker.settings = {
           redpanda = {
             developer_mode = true;
             empty_seed_starts_cluster = true;
@@ -37,9 +37,9 @@ rebuildableTest {
         #   enable = true;
         #   file = ./io-config.yaml;
         # };
-        settings.developer_mode = false;
+        broker.settings.developer_mode = false;
         # XXX: what are these settings? do they do anything? I couldn't find them in the documentation
-        settings.rpk = {
+        broker.settings.rpk = {
           ballast_file_size = "1B";
           tune_net = true;
           tune_disk_scheduler = true;
@@ -63,7 +63,7 @@ rebuildableTest {
       services.redpanda = {
         enable = true;
         admin.password = builtins.toFile "admin.password" "admin";
-        settings = {
+        broker.settings = {
           redpanda = {
             developer_mode = true;
             empty_seed_starts_cluster = true;

--- a/tests/redpanda.nix
+++ b/tests/redpanda.nix
@@ -12,7 +12,7 @@ rebuildableTest {
       virtualisation.memorySize = 2 * 1024; # 2GiB
       services.redpanda = {
         enable = true;
-        settings.broker = {
+        settings = {
           redpanda = {
             developer_mode = true;
             empty_seed_starts_cluster = true;
@@ -37,9 +37,9 @@ rebuildableTest {
         #   enable = true;
         #   file = ./io-config.yaml;
         # };
-        settings.broker.developer_mode = false;
+        settings.developer_mode = false;
         # XXX: what are these settings? do they do anything? I couldn't find them in the documentation
-        settings.broker.rpk = {
+        settings.rpk = {
           ballast_file_size = "1B";
           tune_net = true;
           tune_disk_scheduler = true;
@@ -64,31 +64,29 @@ rebuildableTest {
         enable = true;
         admin.password = builtins.toFile "admin.password" "admin";
         settings = {
-          broker = {
-            redpanda = {
-              developer_mode = true;
-              empty_seed_starts_cluster = true;
-              kafka_api = [
-                { address = "0.0.0.0"; port = 9092; authentication_method = "sasl"; }
-              ];
-              advertised_kafka_api = [
-                # Required for being accessible from client
-                { address = "authserver"; port = 9092; }
-              ];
-            };
-            pandaproxy.pandaproxy_api = [
-              { address = "0.0.0.0"; port = 8082; authentication_method = "http_basic"; }
+          redpanda = {
+            developer_mode = true;
+            empty_seed_starts_cluster = true;
+            kafka_api = [
+              { address = "0.0.0.0"; port = 9092; authentication_method = "sasl"; }
             ];
-            schema_registry.schema_registry_api = [
-              { address = "0.0.0.0"; port = 8081; authentication_method = "http_basic"; }
+            advertised_kafka_api = [
+              # Required for being accessible from client
+              { address = "authserver"; port = 9092; }
             ];
-            rpk.overprovisioned = false;
           };
-          cluster = {
-            kafka_enable_authorization = true;
-            superusers = [ "admin" ];
-            auto_create_topics_enabled = true;
-          };
+          pandaproxy.pandaproxy_api = [
+            { address = "0.0.0.0"; port = 8082; authentication_method = "http_basic"; }
+          ];
+          schema_registry.schema_registry_api = [
+            { address = "0.0.0.0"; port = 8081; authentication_method = "http_basic"; }
+          ];
+          rpk.overprovisioned = false;
+        };
+        cluster.settings = {
+          kafka_enable_authorization = true;
+          superusers = [ "admin" ];
+          auto_create_topics_enabled = true;
         };
       };
 


### PR DESCRIPTION
~~Comes after #6~~
- [x] move redpanda.settings.cluster -> redpanda.cluster.settings
- [ ] ~~move redpanda-acl -> redpanda.acl~~
- [x] move redpanda.settings -> redpanda.broker.settings

Though maybe we shouldn't do the second change. The question in my mind is: is there any reason to enable `redpanda-acl` without enabling `redpanda` to begin with. And maybe it does make sense to run `redpanda-acl` on a client machine that sets up the ACL on the brokers it has access to.
