### PR TITLE
Make binary cache available via nixConfig in flake?

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 A Nix flake for Redpanda.
 
 Build, configure, run and administrate Redpanda with NixOS.
+
+You can use our nix binary cache [fornybar-open](https://fornybar-open.cachix.org) to prevent rebuilding.

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "NixOS module for Redpanda";
 
+  nixConfig = {
+    extra-substituters = [ "https://fornybar-open.cachix.org" ];
+    extra-trusted-public-keys = [ "fornybar-open.cachix.org-1:n2UA90DZm4B7zxfMRsZzg4CBAWy6Ij6mU7FTaCkyIsI=" ];
+  };
+
   inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
   inputs.pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
 


### PR DESCRIPTION
Is this a good idea or just make it more confusing. When someone run the flake?