### PR TITLE
Proper use of `--exit-when-healthy`

### DIFF
--- a/tests/cluster.nix
+++ b/tests/cluster.nix
@@ -87,9 +87,9 @@ let
         server0.wait_for_unit("redpanda.service")
         server1.wait_for_unit("redpanda.service")
         server2.wait_for_unit("redpanda.service")
-        server0.wait_until_succeeds("rpk cluster health --exit-when-healthy", timeout=100)
-        server1.wait_until_succeeds("rpk cluster health --exit-when-healthy", timeout=100)
-        server2.wait_until_succeeds("rpk cluster health --exit-when-healthy", timeout=100)
+        server0.wait_until_succeeds("rpk cluster health --exit-when-healthy --watch", timeout=100)
+        server1.wait_until_succeeds("rpk cluster health --exit-when-healthy --watch", timeout=100)
+        server2.wait_until_succeeds("rpk cluster health --exit-when-healthy --watch", timeout=100)
         client.succeed("rpk topic create hei --brokers 'server0:9092'", timeout=20)
         client.succeed("echo 'foo' | rpk topic produce hei --brokers 'server1:9092'", timeout=20)
         client.succeed("rpk topic consume hei -n 1 --brokers 'server2:9092'", timeout=20)
@@ -120,7 +120,7 @@ let
           # sanity check redpanda-config succeeded
           s.wait_for_unit("redpanda-config.service")
           # cluster back to healthy
-          s.wait_until_succeeds("rpk cluster health --exit-when-healthy", timeout=100);
+          s.wait_until_succeeds("rpk cluster health --exit-when-healthy --watch", timeout=100);
     '';
   };
 in

--- a/tests/redpanda.nix
+++ b/tests/redpanda.nix
@@ -173,9 +173,11 @@ rebuildableTest {
       assert "User:user-2" in aclLog, "No ACLs created for user-2"
 
     authserver.shutdown()
+    client.shutdown()
 
-    prodserver.start() # May complain about having too little memory, so we run it alone
-    with subtest("Production mode setup test"):
-      prodserver.wait_for_unit("redpanda-setup.service")
+    # FIXME: nixbuild.net crashes, probably due to lack of memory
+    #prodserver.start() # May complain about having too little memory, so we run it alone
+    #with subtest("Production mode setup test"):
+    #  prodserver.wait_for_unit("redpanda-setup.service")
   '';
 }

--- a/tests/redpanda.nix
+++ b/tests/redpanda.nix
@@ -145,20 +145,27 @@ rebuildableTest {
     };
   };
 
+  # "reserve" 15GiB early by allocating it here. The key is to do it in small
+  # increments so nixbuild.net detects the lack of memory. Big increments go
+  # unnoticed by the OOM logic. This is exactly what happens with prodserver
+  # below. It requests too much memory at once, and nixbuild.net doesn't
+  # restart the build as expected.
   testScript = ''
+    x = []
+    for _ in range(1024**2):        # 1 MiB
+      x.append(bytearray(1024*15))  #       * 15 kiB = 15 GiB
+    x = []
 
     print("--> Starting testScript")
     server.start()
     client.start()
+    authserver.start()
 
     with subtest("Simple produce/consume test"):
       server.wait_for_unit("redpanda.service")
       server.wait_until_succeeds("rpk cluster health --exit-when-healthy --watch", timeout=100)
       server.succeed("rpk topic create hei", timeout=100)
       client.succeed("python ${./produce.py} 1>&2", timeout=100)
-
-    server.shutdown()
-    authserver.start()
 
     with subtest("Test authentication enabled"):
       authserver.wait_for_unit("redpanda-acl.service")
@@ -172,12 +179,13 @@ rebuildableTest {
       assert "User:user-1" in aclLog, "No ACLs created for user-1"
       assert "User:user-2" in aclLog, "No ACLs created for user-2"
 
+    # Shutdown everything to reclaim memory for prodserver
+    server.shutdown()
     authserver.shutdown()
     client.shutdown()
 
-    # FIXME: nixbuild.net crashes, probably due to lack of memory
-    #prodserver.start() # May complain about having too little memory, so we run it alone
-    #with subtest("Production mode setup test"):
-    #  prodserver.wait_for_unit("redpanda-setup.service")
+    prodserver.start()
+    with subtest("Production mode setup test"):
+      prodserver.wait_for_unit("redpanda-setup.service")
   '';
 }

--- a/tests/redpanda.nix
+++ b/tests/redpanda.nix
@@ -153,7 +153,7 @@ rebuildableTest {
 
     with subtest("Simple produce/consume test"):
       server.wait_for_unit("redpanda.service")
-      server.wait_until_succeeds("rpk cluster health --exit-when-healthy", timeout=100)
+      server.wait_until_succeeds("rpk cluster health --exit-when-healthy --watch", timeout=100)
       server.succeed("rpk topic create hei", timeout=100)
       client.succeed("python ${./produce.py} 1>&2", timeout=100)
 
@@ -162,7 +162,7 @@ rebuildableTest {
 
     with subtest("Test authentication enabled"):
       authserver.wait_for_unit("redpanda-acl.service")
-      authserver.wait_until_succeeds("rpk cluster health --exit-when-healthy", timeout=100)
+      authserver.wait_until_succeeds("rpk cluster health --exit-when-healthy --watch", timeout=100)
       client.succeed("python ${./auth.py} 1>&2", timeout=100)
 
     with subtest("Test ACL creation"):


### PR DESCRIPTION
As per https://github.com/redpanda-data/redpanda/issues/15818 it also
requires --watch to function properly.
